### PR TITLE
Dependency check and /root/.profile fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The argument are:
 
 3. Mesh ID
 
-  The url givent by mesh for installing new agent.
+  The url given by mesh for installing new agent.
   Go to mesh.fqdn.com > Add agent > Linux / BSD (Uninstall) > Copy **ONLY** the last value with the single quotes.
   You are looking for a 64 charaters long value of random letter case, numbers, and special characters.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The argument are:
 
 3. Mesh ID
 
-  The url given by mesh for installing new agent.
+  The ID given by mesh for installing new agent.
   Go to mesh.fqdn.com > Add agent > Linux / BSD (Uninstall) > Copy **ONLY** the last value with the single quotes.
   You are looking for a 64 charaters long value of random letter case, numbers, and special characters.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The argument are:
 
 3. Mesh agent
 
-  The url givent by mesh for installing new agent.
+  The url given by mesh for installing new agent.
   Go to mesh.fqdn.com > Add agent > Installation Executable Linux / BSD / macOS > **Select the good system type**
   Copy **ONLY** the URL with the quote.
   
@@ -69,3 +69,32 @@ Simply launch the script that match your system with *update* as argument.
 ```bash
 ./rmmagent-linux.sh update
 ```
+
+## Uninstall
+To uninstall agent launch the script with this arguement:
+
+```bash
+./rmmagent-linux.sh uninstall 'Mesh FQDN' 'Mesh ID'
+```
+Note: Single quotes must be around the Mesh ID for it to uninstall the mesh agent properly
+
+The argument are:
+
+2. Mesh FQDN
+
+  Example of FQDN: mesh.fqdn.com 
+
+3. Mesh ID
+
+  The url givent by mesh for installing new agent.
+  Go to mesh.fqdn.com > Add agent > Linux / BSD (Uninstall) > Copy **ONLY** the last value with the single quotes.
+  You are looking for a 64 charaters long value of random letter case, numbers, and special characters.
+
+### Example
+```bash
+./rmmagent-linux.sh uninstall mesh.fqdn.com 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+```
+
+### WARNING
+- You should **only** attempt this if the agent removal feaure on TacticalRMM is not working.
+- Running uninstall will **not** remove the connections from the TacticalRMM and MeshCentral Dashboard. You will need to manually remove them. It only forcefully removes the agents from your linux box.

--- a/rmmagent-linux.sh
+++ b/rmmagent-linux.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+if ! command -v unzip &> /dev/null
+then
+        echo "unzip could not be found. Please install unzip."
+        exit 0
+fi
+
 if [[ $1 == "" ]]; then
         echo "First argument is empty !"
         echo "Type help for more information"

--- a/rmmagent-linux.sh
+++ b/rmmagent-linux.sh
@@ -14,7 +14,7 @@ fi
 if [[ $1 == "help" ]]; then
         echo "There is help but more information is available at github.com/ZoLuSs/rmmagent-script"
         echo ""
-        echo "List of argument (no argument name):"
+        echo "List of INSTALL/UPDATE argument (no argument name):"
         echo "Arg 1: 'install' or 'update'"
         echo "Arg 2: System type 'amd64' 'x86' 'arm64' 'armv6'"
         echo "Arg 3: Mesh agent URL"
@@ -24,12 +24,18 @@ if [[ $1 == "help" ]]; then
         echo "Arg 7: Auth Key"
         echo "Arg 8: Agent Type 'server' or 'workstation'"
         echo ""
+        echo "List of UNINSTALL argument (no argument name):"
+        echo "Arg 1: 'uninstall'"
+        echo "Arg 2: Mesh agent FQDN (i.e. mesh.domain.com)"
+        echo "Arg 3: Mesh agent id (The id needs to have single quotes around it)"
+        echo ""
         echo "Only argument 1 is needed for update"
+        echo ""
         exit 0
 fi
 
-if [[ $1 != "install" && $1 != "update" ]]; then
-        echo "First argument can only be 'install' or 'update' !"
+if [[ $1 != "install" && $1 != "update" && $1 != "uninstall" ]]; then
+        echo "First argument can only be 'install' or 'update' or 'uninstall' !"
         echo "Type help for more information"
         exit 1
 fi
@@ -40,7 +46,7 @@ if [[ $1 == "install" && $2 == "" ]]; then
         exit 1
 fi
 
-if [[ $2 != "amd64" && $2 != "x86" && $2 != "arm64" && $2 != "armv6" ]]; then
+if [[ $1 == "install" && $2 != "amd64" && $2 != "x86" && $2 != "arm64" && $2 != "armv6" ]]; then
         echo "This argument can only be 'amd64' 'x86' 'arm64' 'armv6' !"
         echo "Type help for more information"
         exit 1
@@ -88,6 +94,18 @@ if [[ $1 == "install" && $8 != "server" && $8 != "workstation" ]]; then
         exit 1
 fi
 
+if [[ $1 == "uninstall" && $2 == "" ]]; then
+        echo "Argument 2 (Mesh agent FQDN) is empty !"
+        echo "Type help for more information"
+        exit 1
+fi
+
+if [[ $1 == "uninstall" && $3 == "" ]]; then
+        echo "Argument 3 (Mesh agent id) is empty !"
+        echo "Type help for more information"
+        exit 1
+fi
+
 ## Setting var for easy scription
 system=$2
 mesh_url=$3
@@ -96,6 +114,9 @@ rmm_client_id=$5
 rmm_site_id=$6
 rmm_auth=$7
 rmm_agent_type=$8
+## Uninstall var for easy scription
+mesh_fqdn=$2
+mesh_id=$3
 
 go_url_amd64="https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
 go_url_x86="https://go.dev/dl/go1.18.3.linux-386.tar.gz"
@@ -215,6 +236,25 @@ function check_profile () {
         source $profile_file
 }
 
+function uninstall_agent() {
+        systemctl stop tacticalagent
+        systemctl disable tacticalagent
+        rm /etc/systemd/system/tacticalagent.service
+        systemctl daemon-reload
+        rm /usr/local/bin/rmmagent
+        rm /etc/tacticalagent
+        sed -i "/export\ PATH\=\$PATH\:\/usr\/local\/go\/bin/d" /root/.profile
+}
+
+function uninstall_mesh() {
+        (wget "https://$mesh_fqdn/meshagents?script=1" -O /tmp/meshinstall.sh || wget "https://$mesh_fqdn/meshagents?script=1" --no-proxy -O /tmp/meshinstall.sh)
+        chmod 755 /tmp/meshinstall.sh
+        (/tmp/meshinstall.sh uninstall https://$mesh_fqdn $mesh_id || /tmp/meshinstall.sh uninstall uninstall uninstall https://$mesh_fqdn $mesh_id)
+        rm /tmp/meshinstall.sh
+        rm meshagent
+        rm meshagent.msh
+}
+
 case $1 in
 install)
         check_profile
@@ -230,5 +270,12 @@ update)
         agent_compile
         update_agent
         echo "Tactical Agent Update is done"
+        exit 0;;
+uninstall)
+        check_profile
+        uninstall_agent
+        uninstall_mesh
+        echo "Tactical Agent Uninstall is done"
+        echo "You may need to manually remove the agents orphaned connections on TacticalRMM and MeshCentral"
         exit 0;;
 esac

--- a/rmmagent-linux.sh
+++ b/rmmagent-linux.sh
@@ -121,11 +121,9 @@ function go_install() {
         
         tar -xvzf /tmp/golang.tar.gz -C /usr/local/
         rm /tmp/golang.tar.gz
-        export PATH=$PATH:/usr/local/go/bin
         export GOPATH=/usr/local/go
         export GOCACHE=/root/.cache/go-build
 
-        echo "export PATH=$PATH:/usr/local/go/bin" >> /root/.profile
         echo "Golang Install Done !"
 }
 
@@ -219,8 +217,8 @@ function check_profile () {
 
 case $1 in
 install)
-        go_install
         check_profile
+        go_install
         install_mesh
         agent_compile
         install_agent


### PR DESCRIPTION
- Added a dependency check for unzip. If unzip is not found the script will exit.
- Fixes for the /root/.profile file:
  - Fixed the issue when installing the LinuxRMM-Script the /root/.profile PATH variable is incorrect.
  - Added a check_profile function to check the integrity of the /root/.profile PATH variable and correct any issues it my find. Running the update function will correct the profile as well.
- Fixed a bug with doubling the PATH variable in the /root/.profile
- Added uninstall feature.
- Updated documentation for how to use the uninstall feature.