### PR TITLE
Add optional insecure flag for self-signed certificates in script

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ The system architecture is now detected automatically using the following logic:
 
 This ensures the script adapts to different system types automatically without needing manual input.
 
+## Optional insecure flag
+
+If you are using a self-signed certificate on your mesh server, you can add the argument `--insecure` to the command to avoid certificate issues.
 
 ## Install
 To install the agent, launch the script with this argument:


### PR DESCRIPTION
# Add support for insecure flag in installation script

Add optional --insecure.
Pass -insecure to rmmagent for both initial install and the systemd service (ExecStart).
Add --no-check-certificate to wget when fetching MeshAgent.
Update help output to document the flag.

## Example:

./rmmagent-linux.sh install "<mesh_url>" "<api_url>" <client_id> <site_id> "<auth_key>" server --insecure
Omit --insecure to retain default secure behavior.

## Compatibility

Backwards compatible: default behavior unchanged when the flag is not supplied.

##Testing

Verified install with and without --insecure.
Confirmed: self-signed cert scenarios no longer block API enrollment or MeshAgent download.
Confirmed: rerunning installer no longer errors on existing mesh directory or missing temp files.