### PR TITLE
Compile Agent broken due to missing system variables

### DIFF
--- a/rmmagent-linux.sh
+++ b/rmmagent-linux.sh
@@ -96,6 +96,11 @@ function agent_compile() {
     tar -xf "$TMPDIR/rmmagent.tar.gz" -C "$TMPDIR/"
     rm "$TMPDIR/rmmagent.tar.gz"
     cd "$TMPDIR/rmmagent-master"
+    # Force module mode and use a local module cache
+    export GO111MODULE=on
+    export GOMODCACHE="$TMPDIR/go-mod-cache"
+    export GOCACHE="$TMPDIR/go-build-cache"
+    mkdir -p "$GOMODCACHE"
     case $system in
         amd64) env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o "$TMPDIR/temp_rmmagent" ;;
         x86) env CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -ldflags "-s -w" -o "$TMPDIR/temp_rmmagent" ;;
@@ -103,7 +108,7 @@ function agent_compile() {
         armv6) env CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -ldflags "-s -w" -o "$TMPDIR/temp_rmmagent" ;;
     esac
     cd "$TMPDIR"
-    rm -R "$TMPDIR/rmmagent-master"
+    rm -R "$TMPDIR/rmmagent-master" "$GOMODCACHE" "$GOCACHE"
 }
 
 function update_agent() {


### PR DESCRIPTION
Go >=1.17 uses module mode by default. On newer operating systems this breaks the current install process with error message - 

`go: module cache not found: neither GOMODCACHE nor GOPATH is set`
&
`GOCACHE is not defined and neither $XDG_CACHE_HOME nor $HOME are defined`

The changes introduce new system variables (GO111MODULE, GOMODCACHE & GOCACHE) to allow the build to complete. The changes will also include these GO caches in its cleanup